### PR TITLE
feat(UI): Show match between pass and confirm pass

### DIFF
--- a/confirm-password.js
+++ b/confirm-password.js
@@ -1,0 +1,25 @@
+const passEl = document.getElementById("password");
+const confirmPassEl = document.getElementById("conf_password");
+
+passEl.addEventListener("input", checkPasswordMatch);
+confirmPassEl.addEventListener("input", checkPasswordMatch);
+
+function checkPasswordMatch() {
+    const pass = passEl.value;
+    const confirmPass = confirmPassEl.value;
+    const submitButton = document.querySelector("button");
+
+    if (pass === confirmPass) {
+        passEl.classList.remove("mismatch");
+        passEl.classList.add("match");
+        confirmPassEl.classList.remove("mismatch");
+        confirmPassEl.classList.add("match");
+        submitButton.disabled = false;
+    } else {
+        passEl.classList.remove("match");
+        passEl.classList.add("mismatch");
+        confirmPassEl.classList.remove("match");
+        confirmPassEl.classList.add("mismatch");
+        submitButton.disabled = true;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Sign-Up!</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="confirm-password.js" defer></script>
 </head>
 <body>
     <div class="page-container">

--- a/styles.css
+++ b/styles.css
@@ -43,6 +43,20 @@ input {
     margin-bottom: 0.5rem;
 }
 
+input:focus {
+    border-width: 1rem;
+    border: solid;
+    border-color: black;
+}
+
+input:focus.mismatch {
+    border-color: red;
+}
+
+input:focus.match {
+    border-color: green;
+}
+
 .page-container {
     display: flex;
 }
@@ -78,4 +92,14 @@ input {
 
 .opacity {
     opacity: 0.8;
+}
+
+.mismatch {
+    border-width: 0.1rem;
+    border-color: red;
+}
+
+.match {
+    border-width: 0.1rem;
+    border-color: green;
 }


### PR DESCRIPTION
Initially, the password and confirm password fields start with the standard styling. After the user has altered either of those inputs, add a red border if the fields don't match and green border if the fields do match; this gives the user helpful feedback about their input.